### PR TITLE
fix: add skip for `cds_from_genomic`

### DIFF
--- a/scripts/group_segments.py
+++ b/scripts/group_segments.py
@@ -47,8 +47,9 @@ def main(dataset_dir: list[str], output_file: str, ignore_list: str) -> None:
             for file in os.listdir(gca_path):
                 if not file.endswith(".fna"):
                     continue
+                # Certain assemblies contain two files, one of which we want to ignore because it has CDS info
+                # Examples: GCA_052462815.1, GCA_052463665.1, GCA_052463295.1, GCA_052464535.1
                 if "cds_from_genomic" in file:
-                    # Examples: GCA_052462815.1, GCA_052463665.1, GCA_052463295.1, GCA_052464535.1
                     continue
                 assembly_id = file.split(".")[0]
                 assembly_count += 1


### PR DESCRIPTION
These assemblies: `GCA_052462815.1, GCA_052463665.1, GCA_052463295.1, GCA_052464535.1`

have two files:

```
GCA_052462815.1_ASM5246281v1_cds_from_genomic.fna
GCA_052462815.1_ASM5246281v1_genomic.fna
```

the `cds_from_genomic` file contains CDS, example header:

```
>lcl|PX265571.1_cds_XZX78412.1_1 [gene=PB2] [protein=polymerase PB2] [protein_id=XZX78412.1] [location=1..2280] [gbkey=CDS]
```

We simply want to skip this file.

I chose to check for this particular name to skip these files. I think they are from a particular uploader, but I think it's fine to check for this particular string.